### PR TITLE
Rename Template class to DocumentTemplate

### DIFF
--- a/sdk/Eversign/DocumentTemplate.php
+++ b/sdk/Eversign/DocumentTemplate.php
@@ -38,7 +38,7 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
  *
  * @author Patrick Leeb
  */
-class Template {
+class DocumentTemplate {
 
      /**
      * Set to the Template ID of the template you would like to use


### PR DESCRIPTION
The class Template was not renamed with commit "Changes based on Meeting (10.05.17)". This leads to an error when calling createDocumentFromTemplate(...) on Client class since this expects parameter of type DocumentTemplate.