### PR TITLE
Fixed 'expression is not allowed as class constant value' error with PHP5.5 (fixes #19)

### DIFF
--- a/sdk/Eversign/Config.php
+++ b/sdk/Eversign/Config.php
@@ -17,7 +17,7 @@ class Config {
 
     const DEBUG_MODE = false;
 
-    const AVAILABLE_LANGUAGES = [
+    public static $AVAILABLE_LANGUAGES = [
         'en',
         'da',
         'nl',

--- a/sdk/Eversign/Recipient.php
+++ b/sdk/Eversign/Recipient.php
@@ -96,7 +96,7 @@ class Recipient {
     }
 
     public function setLanguage($language) {
-        if(!in_array($language, Config::AVAILABLE_LANGUAGES)) {
+        if(!in_array($language, Config::$AVAILABLE_LANGUAGES)) {
             throw new \Exception('language not supported');
         }
         $this->language = $language;

--- a/sdk/Eversign/Signer.php
+++ b/sdk/Eversign/Signer.php
@@ -228,7 +228,7 @@ class Signer extends Recipient {
     }
 
     public function setLanguage($language) {
-        if(!in_array($language, Config::AVAILABLE_LANGUAGES)) {
+        if(!in_array($language, Config::$AVAILABLE_LANGUAGES)) {
             throw new \Exception('language not supported');
         }
         return $this->language = $language;


### PR DESCRIPTION
Replaced class `const` array with `public static` variable.