### PR TITLE
issue#32 Extended config.php with 'pt' language code

### DIFF
--- a/example/create-document.php
+++ b/example/create-document.php
@@ -49,7 +49,7 @@ $document->appendSigner($signer);
 $recipient = new Recipient();
 $recipient->setName('John Doe Recipient');
 $recipient->setEmail($config['recipientEmail']);
-$recipient->setLanguage('de');
+$recipient->setLanguage('pt');
 $document->appendRecipient($recipient);
 
 //Set Custom Meta Tags to the Document

--- a/sdk/Eversign/Config.php
+++ b/sdk/Eversign/Config.php
@@ -30,6 +30,7 @@ class Config {
         'es',
         'se',
         'tr',
+        'pt',
     ];
 
 }


### PR DESCRIPTION
@alexeriksen I have added 'pt' language code to Config.php and tested if it is working correctly with several SDK/API calls.
Furthermore, I have modified the create-document.php example to use 'pt' as an additional test, which works correctly.
Please approve, so I can merge and release a new version.