### PR TITLE
Allow Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": "^7.1",
-        "guzzlehttp/guzzle": "^6.2.3",
+        "guzzlehttp/guzzle": "^6.2.3|^7.0.0",
         "jms/serializer": "^1.6.2"
     }
 }


### PR DESCRIPTION
Guzzle 7 is a required upgrade for frameworks such as Laravel 8, and many other packages now also start to require Guzzle 7.

I've searched the Eversign SDK code for [backwards incompatible](
https://github.com/guzzle/guzzle/blob/master/UPGRADING.md) changes as documented in the Upgrade Guide, and it seems this package is perfectly compatible with both Guzzle 6 and Guzzle 7 without any code changes.