### PR TITLE
Add support for requireable in radiofield

### DIFF
--- a/sdk/Eversign/RadioField.php
+++ b/sdk/Eversign/RadioField.php
@@ -28,6 +28,7 @@ namespace Eversign;
 
 use Eversign\CheckboxField;
 use JMS\Serializer\Annotation\Type;
+use Eversign\Requireable;
 
 /**
  * Radio Button fields come with a fixed pixel width and height of 14x14.
@@ -36,6 +37,8 @@ use JMS\Serializer\Annotation\Type;
  * @author Patrick Leeb
  */
 class RadioField extends CheckboxField {
+
+    use Requireable;
 
      /**
      * This parameter is used to identify radio button groups.
@@ -48,6 +51,7 @@ class RadioField extends CheckboxField {
     public function __construct() {
         parent::__construct();
         $this->setGroup(0);
+        $this->setRequired(false);
     }
 
     public function getGroup() {


### PR DESCRIPTION

## Problem

Radio Fields in the API support a required attribute.
However, the SDK does have the Requireable trait for RadioFields.

## Solution

This PR adds the Requireable trait to the RadioField class and sets the setRequired as false in the constructor.
I'm not aware of any unit tests but if they are, please let me know and I'll update.

## Notes

API Docs: https://eversign.com/api/documentation/fields#radio-fields