### PR TITLE
Allow PHP 8 & require JMS serializer 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "sami/sami": "3.3.*"
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "guzzlehttp/guzzle": "^6.2.3|^7.0.0",
-        "jms/serializer": "^1.6.2"
+        "jms/serializer": "^3.12.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
     "require": {
         "php": "^7.1|^8.0",
         "guzzlehttp/guzzle": "^6.2.3|^7.0.0",
-        "jms/serializer": "^3.12.0"
+        "jms/serializer": "^1.6.2|^3.12.0"
     }
 }


### PR DESCRIPTION
After extensively reading the upgrade guides, I can't find any direct compatibility issues with Eversign SDK. 
Might warrant further testing though 😃 