### PR TITLE
Restore PHP 7.1-7.3 support

### DIFF
--- a/sdk/Eversign/ApiRequest.php
+++ b/sdk/Eversign/ApiRequest.php
@@ -46,7 +46,7 @@ class ApiRequest {
 
     private $payLoad;
 
-    private GuzzleClient $guzzleClient;
+    private $guzzleClient;
 
     /**
      * Creating a blank Request with the Access Key and specific Endpoint


### PR DESCRIPTION
Type hinted properties are only supported on PHP 7.4+, so the recent changes in #48 inadvertently broke the package on PHP 7.1-7.3
Removing the type hint fixes the package for older PHP versions.