### PR TITLE
fix: Typo in Document and Signer + add the function downloadFinalDocument()

### DIFF
--- a/sdk/Eversign/ApiRequest.php
+++ b/sdk/Eversign/ApiRequest.php
@@ -236,7 +236,11 @@ class ApiRequest {
         $body = $response->getBody();
 
         if($this->payLoad && is_array($this->payLoad) &&  array_key_exists("sink", $this->payLoad)) {
-            return file_exists($this->payLoad["sink"]);
+            if('stream' === $this->payLoad["sink"]){
+                return $body;
+            }else{
+                return file_exists($this->payLoad["sink"]);
+            }
         } else {
             $responseJson = json_decode($body, true);
             if(json_last_error() !== JSON_ERROR_NONE) {

--- a/sdk/Eversign/ApiRequest.php
+++ b/sdk/Eversign/ApiRequest.php
@@ -202,6 +202,16 @@ class ApiRequest {
                 }
             ]);
         }
+        else if($this->payLoad && is_array($this->payLoad) && array_key_exists("stream", $this->payLoad)) {
+            $response = $this->guzzleClient->request($this->httpType, $this->endPoint, [
+                'timeout' => $this->guzzleRequestTimeout,
+                'query' => $this->createQuery(),
+                'stream' => $this->payLoad["stream"],
+                'on_stats' => function (TransferStats $stats) use (&$effectiveUrl) {
+                    $effectiveUrl = $stats->getEffectiveUri();
+                }
+            ]);
+        }
         else {
             $requestOptions = [
                 'timeout' => $this->guzzleRequestTimeout,
@@ -236,11 +246,10 @@ class ApiRequest {
         $body = $response->getBody();
 
         if($this->payLoad && is_array($this->payLoad) &&  array_key_exists("sink", $this->payLoad)) {
-            if('stream' === $this->payLoad["sink"]){
-                return $body;
-            }else{
-                return file_exists($this->payLoad["sink"]);
-            }
+           return file_exists($this->payLoad["sink"]);
+
+        } else if($this->payLoad && is_array($this->payLoad) &&  array_key_exists("stream", $this->payLoad)) {
+            return $body;
         } else {
             $responseJson = json_decode($body, true);
             if(json_last_error() !== JSON_ERROR_NONE) {

--- a/sdk/Eversign/Client.php
+++ b/sdk/Eversign/Client.php
@@ -582,7 +582,7 @@ class Client {
             "url_only" => $onlyUrl
         ];
 
-        $payLoad = $onlyUrl ? null : ["sink" => 'stream'];
+        $payLoad = $onlyUrl ? null : ["stream" => false];
 
         $request = new ApiRequest(
             "GET",

--- a/sdk/Eversign/Client.php
+++ b/sdk/Eversign/Client.php
@@ -572,6 +572,32 @@ class Client {
         return $request->startRequest();
      }
 
+    public function downloadFinalDocument(Document $document, $auditTrail = 0, $onlyUrl = false, $documentId = "") {
+
+        $parameters = [
+            "business_id" => $this->selectedBusiness->getBusinessId(),
+            "document_hash" => $document->getDocumentHash(),
+            "audit_trail" => $auditTrail,
+            "document_id" => $documentId,
+            "url_only" => $onlyUrl
+        ];
+
+        $payLoad = $onlyUrl ? null : ["sink" => 'stream'];
+
+        $request = new ApiRequest(
+            "GET",
+            $this->accessKey,
+            'download_final_document',
+            $onlyUrl ? "Eversign\Url" : "",
+            $parameters,
+            $payLoad,
+            $this->apiBaseUrl,
+            $this->apiRequestTimeout
+        );
+
+        return $request->startRequest();
+    }
+
      /**
       * Deletes the specified Document. Only works on Drafts and canceled Documents
       * @param \Eversign\Document $document

--- a/sdk/Eversign/Document.php
+++ b/sdk/Eversign/Document.php
@@ -515,7 +515,7 @@ class Document {
     }
 
     public function getFlexibleSigning() {
-        return $this->getFlexibleSigning;
+        return $this->flexibleSigning;
     }
 
     public function appendMeta($key, $value) {

--- a/sdk/Eversign/Signer.php
+++ b/sdk/Eversign/Signer.php
@@ -179,7 +179,7 @@ class Signer extends Recipient {
         return !!$this->signed;
     }
 
-    public function getSigned_timestamp() {
+    public function getSignedTimestamp() {
         return $this->signed_timestamp;
     }
 
@@ -235,7 +235,7 @@ class Signer extends Recipient {
         $this->signed = !!$signed;
     }
 
-    public function setSigned_timestamp($signed_timestamp) {
+    public function setSignedTimestamp($signed_timestamp) {
         $this->signed_timestamp = $signed_timestamp;
     }
 

--- a/sdk/Eversign/Url.php
+++ b/sdk/Eversign/Url.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Patrick Leeb.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace Eversign;
+
+use JMS\Serializer\Annotation\Type;
+
+class Url {
+
+     /**
+     * @var boolean $success
+     * @Type("boolean")
+     */
+    public $success;
+
+     /**
+     * @var boolean $success
+     * @Type("string")
+     */
+    public $url;
+
+
+}


### PR DESCRIPTION
To avoid issue with some IDE / Framework, I fixed the Typo of Document and Signer with Getter.

I added the possibility  to stream the result of PDF document or to get the direct URL.

I added the condition with a "[stream](https://docs.guzzlephp.org/en/stable/request-options.html#stream)" payload. I think if we keep this logic, we have to refactor `startRequest()`
The idea is there, you can change if needed :)