### PR TITLE
Remove usage of the Annotation Registry as it's been removed and allow update to doctrine/annotations:^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,6 @@
         "php": "^7.1|^8.0",
         "guzzlehttp/guzzle": "^6.2.3|^7.0.0",
         "jms/serializer": "^1.6.2|^3.12.0",
-        "doctrine/annotations": "^1.9"
+        "doctrine/annotations": "^1.9|^2.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,34 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0aacf503ecda685602751bed005454ce",
+    "content-hash": "9cd47f548e995b32c729d2f173a43dcc",
     "packages": [
         {
             "name": "doctrine/annotations",
-            "version": "1.14.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "ad785217c1e9555a7d6c6c8c9f406395a5e2882b"
+                "reference": "d02c9f3742044e17d5fa8d28d8402a2d95c33302"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/ad785217c1e9555a7d6c6c8c9f406395a5e2882b",
-                "reference": "ad785217c1e9555a7d6c6c8c9f406395a5e2882b",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/d02c9f3742044e17d5fa8d28d8402a2d95c33302",
+                "reference": "d02c9f3742044e17d5fa8d28d8402a2d95c33302",
                 "shasum": ""
             },
             "require": {
-                "doctrine/lexer": "^1 || ^2",
+                "doctrine/lexer": "^2 || ^3",
                 "ext-tokenizer": "*",
-                "php": "^7.1 || ^8.0",
+                "php": "^7.2 || ^8.0",
                 "psr/cache": "^1 || ^2 || ^3"
             },
             "require-dev": {
-                "doctrine/cache": "^1.11 || ^2.0",
-                "doctrine/coding-standard": "^9 || ^10",
-                "phpstan/phpstan": "~1.4.10 || ^1.8.0",
+                "doctrine/cache": "^2.0",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.8.0",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "symfony/cache": "^4.4 || ^5.4 || ^6",
+                "symfony/cache": "^5.4 || ^6",
                 "vimeo/psalm": "^4.10"
             },
             "suggest": {
@@ -78,31 +78,35 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.14.2"
+                "source": "https://github.com/doctrine/annotations/tree/2.0.0"
             },
-            "time": "2022-12-15T06:48:22+00:00"
+            "time": "2022-12-19T18:17:20+00:00"
         },
         {
             "name": "doctrine/deprecations",
-            "version": "v1.0.0",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de"
+                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
-                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
+                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1|^8.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^9",
-                "phpunit/phpunit": "^7.5|^8.5|^9.5",
-                "psr/log": "^1|^2|^3"
+                "phpstan/phpstan": "1.4.10 || 1.10.15",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psalm/plugin-phpunit": "0.18.4",
+                "psr/log": "^1 || ^2 || ^3",
+                "vimeo/psalm": "4.30.0 || 5.12.0"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -121,9 +125,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.0.0"
+                "source": "https://github.com/doctrine/deprecations/tree/v1.1.1"
             },
-            "time": "2022-05-02T15:47:09+00:00"
+            "time": "2023-06-03T09:27:29+00:00"
         },
         {
             "name": "doctrine/instantiator",

--- a/sdk/Eversign/Client.php
+++ b/sdk/Eversign/Client.php
@@ -30,7 +30,6 @@ use Eversign\ApiRequest;
 use Eversign\OAuthTokenRequest;
 use Eversign\Business;
 use Eversign\Config;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use JMS\Serializer\SerializerBuilder;
 
 class Client {
@@ -72,9 +71,6 @@ class Client {
       */
      public function __construct($accessKey = null, $businessId = 0, $apiBaseUrl = null, int $apiRequestTimeout = Config::GUZZLE_TIMEOUT)
      {
-        if (!class_exists('Doctrine\Common\Annotations\AnnotationRegistry', false) && class_exists('Doctrine\Common\Annotations\AnnotationRegistry')) {
-            AnnotationRegistry::registerLoader('class_exists');
-        }
         $this->accessKey = $accessKey;
 
         if($businessId != 0) {

--- a/sdk/Eversign/Document.php
+++ b/sdk/Eversign/Document.php
@@ -29,8 +29,6 @@ namespace Eversign;
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\SerializerBuilder;
 use Eversign\FormField;
-use Doctrine\Common\Annotations\AnnotationRegistry;
-
 
 /**
  * Documents are used by Signers to create legally Binding electronic signatures
@@ -285,8 +283,6 @@ class Document {
 
 
     public function __construct() {
-        AnnotationRegistry::registerLoader('class_exists');
-
         $this->setSandbox(false);
         $this->setIsDraft(false);
         $this->setUseSignerOrder(false);

--- a/sdk/Eversign/DocumentTemplate.php
+++ b/sdk/Eversign/DocumentTemplate.php
@@ -29,7 +29,6 @@ namespace Eversign;
 
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\SerializerBuilder;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 
 /**
  * An existing template can be used by making an HTTP POST request to the
@@ -146,9 +145,6 @@ class DocumentTemplate {
     private $customRequesterName;
 
     public function __construct($templateId = null) {
-        if (!class_exists('Doctrine\Common\Annotations\AnnotationRegistry', false) && class_exists('Doctrine\Common\Annotations\AnnotationRegistry')) {
-            AnnotationRegistry::registerLoader('class_exists');
-        }
         $this->signers = [];
         $this->recipients = [];
         $this->setSandbox(false);
@@ -240,7 +236,7 @@ class DocumentTemplate {
     public function getEmbeddedSigningEnabled() {
         return !!$this->embeddedSigningEnabled;
     }
-    
+
     public function getCustomRequesterEmail() {
         return $this->customRequesterEmail;
     }

--- a/sdk/Eversign/Info.php
+++ b/sdk/Eversign/Info.php
@@ -29,7 +29,6 @@ namespace Eversign;
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\SerializerBuilder;
 use Eversign\FormField;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 
 
 /**
@@ -60,10 +59,6 @@ class Info {
      * @Type("string")
      */
     private $businessUrl;
-
-    public function __construct() {
-        AnnotationRegistry::registerLoader('class_exists');
-    }
 
     /**
      * Converts the document to a JSON String


### PR DESCRIPTION
In #74 and #75 the doctrine/annotations package is locked specifically to ^1.9 as the Annotation Registry is used and that has been removed from version 2 onwards. This makes it impossible to upgrade other packages that rely on the new annotations package version. 